### PR TITLE
improves images' resolution

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,11 +18,9 @@ async function fetchArticles() {
   // .special might include some "random" articles
   const articles = $('#hnews').parent().find('article').not('.special').map(function() {
     const heading = $(this).find('.heading');
-    const thumbnail = $(this).find('img').attr('src');
     return {
       title: heading.text(),
-      link: `${BASE_URL}${heading.find('a').attr('href')}`,
-      thumbnail: `${BASE_URL}${thumbnail}`
+      link: `${BASE_URL}${heading.find('a').attr('href')}`
     };
   }).toArray();
 
@@ -81,6 +79,21 @@ async function fetchImageId(url) {
   }
 }
 
+async function fetchImageUrl(url) {
+  try {
+  const response = await axios(url);
+  const $ = cheerio.load(response.data);
+  const singleImage = $('.page-mainimage').find('img').attr('src');
+  const doubleImage = $('.swiper-articleimage li.swiper-slide[data-hash="slide1"]').find('img.swiper-lazy').attr('src');
+  const imageUrl = singleImage || doubleImage;
+
+  return `${BASE_URL}${imageUrl}`;
+
+  } catch (e) {
+    console.error(e)
+  }
+}
+
 async function homeTimeline() {
   try {
     const response = await client.get('statuses/user_timeline', {});
@@ -98,11 +111,16 @@ exports.handler = async function handler() {
   const [articles, tweets] = await Promise.all([fetchFirst3Articles(), homeTimeline()]);
   const newArticles = articles.filter(article => !tweets.includes(article.title));
 
-  console.log('New articles: ', newArticles);
+  const articlesWithImage = await Promise.all(newArticles.map(async (article) => {
+    article.imageUrl = await fetchImageUrl(article.link);
+    return article;
+  }));
 
-  for (const article of newArticles) {
+  console.log('New articles: ', articlesWithImage);
+
+  for (const article of articlesWithImage) {
     const status = [article.title, `Read more: ${article.link}`].join('\n');
-    const media_ids = await fetchImageId(article.thumbnail);
+    const media_ids = await fetchImageId(article.imageUrl);
     const response = await postTweet({status, media_ids});
 
     console.log('Tweet response: ', response);


### PR DESCRIPTION
Closes #14.

## Summary

PR #13 introduced images on tweets. However, the first implementation used thumbnail images, which had low resolution and therefore became blurry. This PR introduces a new workflow for fetching images from the main article page (high-resolution).

## Considerations
An article may have one or more images. When the article contains one image only, its parent element has class `.page-mainimage` and this is used to scrape the image URL.

If an article has multiple images, they are displayed inside a carousel/swiper component. In this case, the main image is assumed to be inside the element which has `data-hash=slide1`. Also, the images are lazy loaded. For this reason, the image URLs are scraped using the initial HTML since the scraping is done before the HTML structure of the carousel is completely mounted.

After scraping the image URL, the workflow remains the same as in #13.

## Results

This PR was tested using both types of articles (single image and multiple image) and both worked. In order to save you from seeing my face too much, I only uploaded one tweet using my twitter account (followers are always welcome 🍪).

![image](https://user-images.githubusercontent.com/18402838/78404444-bd856380-75fe-11ea-9379-c6cb7f627f77.png)

## References
- Article with one image: https://www.berlin.de/en/news/coronavirus/6122241-6098215-coronavirus-restrictions-longer-stay-in-.en.html
- Article with 2 images: https://www.berlin.de/en/news/coronavirus/6123872-6098215-retail-calls-on-supermarket-customers-to.en.html


