### PR TITLE
Adds multiple image tweets

### DIFF
--- a/index.js
+++ b/index.js
@@ -156,5 +156,3 @@ exports.handler = async function handler() {
     console.log('Tweet response: ', response);
   }
 };
-
-exports.handler();

--- a/index.js
+++ b/index.js
@@ -84,9 +84,7 @@ async function fetchImageId(url) {
 
 async function fetchImageIds(urls) {
   try {
-    const ids = await Promise.all(
-      urls.map(async (url) => await fetchImageId(url)),
-    );
+    const ids = await Promise.all(urls.map(fetchImageId));
     return ids.join();
   } catch (e) {
     console.error(e);

--- a/index.js
+++ b/index.js
@@ -76,16 +76,17 @@ async function fetchImage(url) {
   }
 }
 
+async function fetchImageId(url) {
+  const image = await fetchImage(url);
+  const id = await postImage(image);
+  return id;
+}
+
 async function fetchImageIds(urls) {
   try {
     const ids = await Promise.all(
-      urls.map(async (url) => {
-        const image = await fetchImage(url);
-        const id = await postImage(image);
-        return id;
-      }),
+      urls.map(async (url) => await fetchImageId(url)),
     );
-
     return ids.join();
   } catch (e) {
     console.error(e);
@@ -96,13 +97,11 @@ async function fetchImageUrl(url) {
   try {
     const response = await axios(url);
     const $ = cheerio.load(response.data);
-    const singleImageElement = $('.page-mainimage').find('img');
-    const multipleImageElement = $('.swiper-wrapper').find('img');
+    const imageElement = $(
+      '.main-content .page-mainimage,.main-content .swiper-wrapper',
+    ).find('img');
 
-    const element = singleImageElement.length
-      ? singleImageElement
-      : multipleImageElement;
-    const imageURls = element
+    const imageURls = imageElement
       .map(
         (index, imageTag) =>
           `${BASE_URL}${
@@ -157,3 +156,5 @@ exports.handler = async function handler() {
     console.log('Tweet response: ', response);
   }
 };
+
+exports.handler();


### PR DESCRIPTION
Closes #18.

## Summary

Currently we only post tweets with one image. However, there are articles that contain multiple images. Since the Twitter API lets us attach multiple images in a tweet (up to 4), this PR introduces this feature.

## Considerations
There are two types of articles: single image and multiple image articles. For the multiple image articles, images are lazy loaded except for the main image of the article. This changes not only how the images are rendered, but how they are declared in the HTML (thus affecting our scraping). In the main image, the image URL can be found in the src attribute of the img tag. However, for the lazy loaded images, a data-src attribute is used.

## Results

This PR was tested using multiple image articles and this is the awesome result:

![2020-04-26_03h45_54](https://user-images.githubusercontent.com/18402838/80297921-f7720180-8787-11ea-96b5-d18158f01e58.png)






